### PR TITLE
Added navigation that does not reload the navigation linked target pages

### DIFF
--- a/_includes/custom_scripts.html
+++ b/_includes/custom_scripts.html
@@ -1,0 +1,12 @@
+{% for script in site.static_files %}
+  {% if script.path contains '/assets/js/custom/' and script.extname == '.js' %}
+    {% if script.name == 'copy-to-clipboard.js' %}
+      {% if site.enable_copy_code_button == true %}
+        <script src="https://cdn.jsdelivr.net/npm/clipboard@1/dist/clipboard.min.js"></script>
+        <script src="{{ script.path | relative_url }}"></script>
+      {% endif %}
+    {% else %}
+      <script src="{{ script.path | relative_url }}"></script>
+    {% endif %}
+  {% endif %}
+{% endfor %}

--- a/_includes/nav_list_add
+++ b/_includes/nav_list_add
@@ -8,15 +8,14 @@
 {% endif %}
 
 {% comment %} {% assign debugInfo = "levelIndex: " | append: levelIndex | append: ", levelDepth: " | append: levelDepth %}
-<div style="color: red;">{{ debugInfo }}</div>  {% endcomment %}
+<div style="color: red;">{{ debugInfo }}</div> {% endcomment %}
 
 {% assign levelDepth = levelDepth | plus: 1 %}
 
 {% if levelIndex == 0 %}
 {% else %}
   {% comment %} {% assign debugInfo = "nav.title: " | append: nav.title | append: ", nav.url: " | append: nav.url | append: ", nav.count: " | append: nav.subnav.count %}
-  <div style="color: red;">{{ debugInfo }}</div> 
-  {% endcomment %}
+  <div style="color: red;">{{ debugInfo }}</div> {% endcomment %}
 
   {% assign preFixed = "/" | append: nav.url %}
   {% if (nav.url == page.url or preFixed == page.url) %}
@@ -26,38 +25,16 @@
   {% endif %}  
 
   <input type="checkbox" id="toggle-{{levelIndex}}"/>
-  <label for="toggle-{{levelIndex}}" class="{{titleStyle}} {{active}}">
-    <a href="{{ nav.url | relative_url }}"
-    {% comment %} >
-      <span  {% endcomment %}
-      {% comment %} class="{{titleStyle}} {{active}}" {% endcomment %}
-      >
-        {{ nav.title }}
-      {% comment %} </span> {% endcomment %}
-    </a>
-  </label> 
-  
-  {% comment %} <a href="{{ nav.url | relative_url }}">
-  </a> {% endcomment %}
-
-  {% comment %} <label for="toggle-{{levelIndex}}">{{ nav.title }}</label> {% endcomment %}
-
-  {% comment %} <span for="toggle-{{levelIndex}}" class="nav__sub-title">{{ nav.title }}</span> {% endcomment %}
-  {% comment %} {% if nav.url %}
-    <a href="{{ nav.url | relative_url }}"><span class="nav__sub-title {{active}}">{{ nav.title }}</span></a>
-  {% else %} 
-    <label for="toggle-{{levelIndex}}">{{ nav.title }}</label>
-  {% endif %}  {% endcomment %}
-  
+  <label for="toggle-{{levelIndex}}" class="{{titleStyle}} {{active}}">    
+    <a href="{{ nav.url | relative_url }}" class="nav-link">{{ nav.title }}</a>
+  </label>   
 {% endif %}
 
 <ul class="nav__items">
   {% for nav in navigation %}
     <li>
-      {% comment %} 
-      {% assign debugInfo = "nav.url: " | append: nav.url | append: ", page.url: " | append: page.url %}
-      <div style="color: red;">{{ debugInfo }}</div> 
-      {% endcomment %}
+      {% comment %} {% assign debugInfo = "nav.url: " | append: nav.url | append: ", page.url: " | append: page.url %}
+      <div style="color: red;">{{ debugInfo }}</div> {% endcomment %}
 
       {% assign preFixed = "/" | append: nav.url %}
       {% if (nav.url == page.url or preFixed == page.url) %}
@@ -71,7 +48,7 @@
         {% include nav_list_add nav=nav.subnav levelIndex=nextLevelIndex levelDepth=levelDepth%}
       {% else %}
         {% if nav.url %}
-          <a href="{{ nav.url | relative_url }}" class="{{active}}{% if levelDepth < 2 %} {{titleStyle}}{% endif %}">{{ nav.title }}</a>
+          <a href="{{ nav.url | relative_url }}" class="nav-link {{active}}{% if levelDepth < 2 %} {{titleStyle}}{% endif %}">{{ nav.title }}</a>
         {% else %}
           <span>{{ nav.title }}</span>
         {% endif %}

--- a/_includes/paginator.html
+++ b/_includes/paginator.html
@@ -5,9 +5,9 @@
     {% comment %} Link for previous page {% endcomment %}
     {% if paginator.previous_page %}
       {% if paginator.previous_page == 1 %}
-        <li><a href="{{ first_page_path }}">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</a></li>
+        <li><a href="{{ first_page_path }}" class="nav-link">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</a></li>
       {% else %}
-        <li><a href="{{ site.paginate_path | replace: ':num', paginator.previous_page | replace: '//', '/' | relative_url }}">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</a></li>
+        <li><a href="{{ site.paginate_path | replace: ':num', paginator.previous_page | replace: '//', '/' | relative_url }}" class="nav-link">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</a></li>
       {% endif %}
     {% else %}
     <li><a href="#" class="disabled"><span aria-hidden="true">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</span></a></li>
@@ -17,7 +17,7 @@
     {% if paginator.page == 1 %}
       <li><a href="#" class="disabled current">1</a></li>
     {% else %}
-      <li><a href="{{ first_page_path }}">1</a></li>
+      <li><a href="{{ first_page_path }}" class="nav-link">1</a></li>
     {% endif %}
 
     {% assign page_start = 2 %}
@@ -43,7 +43,7 @@
           {% comment %} Distance must be a positive value {% endcomment %}
           {% assign dist = 0 | minus: dist %}
         {% endif %}
-        <li><a href="{{ site.paginate_path | replace: ':num', index | relative_url }}">{{ index }}</a></li>
+        <li><a href="{{ site.paginate_path | replace: ':num', index | relative_url }}" class="nav-link">{{ index }}</a></li>
       {% endif %}
     {% endfor %}
 
@@ -55,12 +55,12 @@
     {% if paginator.page == paginator.total_pages %}
       <li><a href="#" class="disabled current">{{ paginator.page }}</a></li>
     {% else %}
-      <li><a href="{{ site.paginate_path | replace: ':num', paginator.total_pages | replace: '//', '/' | relative_url }}">{{ paginator.total_pages }}</a></li>
+      <li><a href="{{ site.paginate_path | replace: ':num', paginator.total_pages | replace: '//', '/' | relative_url }}" class="nav-link">{{ paginator.total_pages }}</a></li>
     {% endif %}
 
     {% comment %} Link next page {% endcomment %}
     {% if paginator.next_page %}
-      <li><a href="{{ site.paginate_path | replace: ':num', paginator.next_page | replace: '//', '/' | relative_url }}">{{ site.data.ui-text[site.locale].pagination_next | default: "Next" }}</a></li>
+      <li><a href="{{ site.paginate_path | replace: ':num', paginator.next_page | replace: '//', '/' | relative_url }}" class="nav-link">{{ site.data.ui-text[site.locale].pagination_next | default: "Next" }}</a></li>
     {% else %}
       <li><a href="#" class="disabled"><span aria-hidden="true">{{ site.data.ui-text[site.locale].pagination_next | default: "Next" }}</span></a></li>
     {% endif %}

--- a/_includes/post_pagination.html
+++ b/_includes/post_pagination.html
@@ -1,12 +1,12 @@
 {% if page.previous or page.next %}
   <nav class="pagination">
     {% if page.previous %}
-      <a href="{{ page.previous.url | relative_url }}" class="pagination--pager" title="{{ page.previous.title | markdownify | strip_html }}">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</a>
+      <a href="{{ page.previous.url | relative_url }}" class="pagination--pager nav-link" title="{{ page.previous.title | markdownify | strip_html }}">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</a>
     {% else %}
       <a href="#" class="pagination--pager disabled">{{ site.data.ui-text[site.locale].pagination_previous | default: "Previous" }}</a>
     {% endif %}
     {% if page.next %}
-      <a href="{{ page.next.url | relative_url }}" class="pagination--pager" title="{{ page.next.title | markdownify | strip_html }}">{{ site.data.ui-text[site.locale].pagination_next | default: "Next" }}</a>
+      <a href="{{ page.next.url | relative_url }}" class="pagination--pager nav-link" title="{{ page.next.title | markdownify | strip_html }}">{{ site.data.ui-text[site.locale].pagination_next | default: "Next" }}</a>
     {% else %}
       <a href="#" class="pagination--pager disabled">{{ site.data.ui-text[site.locale].pagination_next | default: "Next" }}</a>
     {% endif %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -18,10 +18,7 @@
   {%- endcase -%}
 {% endif %}
 
-{% if site.enable_copy_code_button == true %}
-  <script src="https://cdn.jsdelivr.net/npm/clipboard@1/dist/clipboard.min.js"></script>
-  <script src="{{ '/assets/js/custom/copy-to-clipboard.js' | relative_url }}"></script>
-{% endif %}
+{% include custom_scripts.html %}
 
 {% include analytics.html %}
 {% include /comments-providers/scripts.html %}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -31,7 +31,7 @@ layout: default
       {% unless page.header.overlay_color or page.header.overlay_image %}
         <header>
           {% if page.title %}<h1 id="page-title" class="page__title p-name {% if page.subtitle == null and page.description == null %} page__title_decoration{% endif %}" itemprop="headline">
-            <a href="{{ page.url | absolute_url }}" class="u-url" itemprop="url">{{ page.title | markdownify | remove: "<p>" | remove: "</p>" }}</a>
+            <a href="{{ page.url | absolute_url }}" class="u-url nav-link" itemprop="url">{{ page.title | markdownify | remove: "<p>" | remove: "</p>" }}</a>
           </h1>{% endif %}
           {% if page.subtitle or page.description %}
             {% if page.subtitle %}
@@ -54,8 +54,10 @@ layout: default
             </nav>
           </aside>
         {% endif %}
+
         {{ content }}
-        {% if page.link %}<div><a href="{{ page.link }}" class="btn btn--primary">{{ site.data.ui-text[site.locale].ext_link_label | default: "Direct Link" }}</a></div>{% endif %}
+        
+        {% if page.link %}<div><a href="{{ page.link }}" class="btn btn--primary nav-link">{{ site.data.ui-text[site.locale].ext_link_label | default: "Direct Link" }}</a></div>{% endif %}
       </section>
 
       <footer class="page__meta">

--- a/_sass/minimal-mistakes/minimal-mistakes/_navigation.scss
+++ b/_sass/minimal-mistakes/minimal-mistakes/_navigation.scss
@@ -442,9 +442,7 @@
   ul {
     list-style-type: none;
     display: none;
-    // opacity: 0;
-    // -webkit-transition: 0.3s ease;
-    // transition: opacity 0.3s ease; /* Transition effect on opacity */
+
   }
 
   /* Style for the checkbox */
@@ -454,7 +452,11 @@
 
   input[type="checkbox"]:checked+label+ul {
     display: block;
-    // opacity: 1;  /* Fade in the nested ul */
+    -webkit-animation: $intro-transition;
+    animation: $intro-transition;
+    animation-duration: 0.25s;
+    //animation-delay: 0.05s;
+    //-webkit-animation-delay: 0.05s;
   }
 
   label {
@@ -462,12 +464,6 @@
       display: grid;
     }
     position: relative;
-    //padding: 0.5em 2.5em 0.5em 1em;
-    //color: $gray;
-    //font-size: $type-size-6;
-    //font-weight: bold;
-    //border: 1px solid $light-gray;
-    //border-radius: $border-radius;
     z-index: 20;
     -webkit-transition: 0.2s ease-out;
     transition: 0.2s ease-out;
@@ -512,15 +508,15 @@
   }
 
   /* un-folded */
-//   input:checked + label {
-//     color: white;
-//     background-color: mix(white, #000, 20%);
-// 
-//     &:before,
-//     &:after {
-//       background-color: #fff;
-//     }
-//   }
+  //   input:checked + label {
+  //     color: white;
+  //     background-color: mix(white, #000, 20%);
+  // 
+  //     &:before,
+  //     &:after {
+  //       background-color: #fff;
+  //     }
+  //   }
 
   /* on hover show expand*/
   label:hover:after {

--- a/_sass/minimal-mistakes/minimal-mistakes/_page.scss
+++ b/_sass/minimal-mistakes/minimal-mistakes/_page.scss
@@ -55,6 +55,12 @@ body {
     width: 100%;
     clear: both;
 
+    -webkit-animation: $intro-transition;
+    animation: $intro-transition;
+    -webkit-animation-delay: 0.25s;
+    animation-delay: 0.25s;
+    animation-duration: 0.5s;
+
     .page__content,
     .page__meta,
     .page__share {

--- a/_sass/minimal-mistakes/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/minimal-mistakes/_sidebar.scss
@@ -15,6 +15,7 @@
   //   -webkit-transform: translate3d(0, 0, 0);
   //   transform: translate3d(0, 0, 0);
   // }
+  overflow-x: hidden;
 
   @include breakpoint($large) {
     float: left;

--- a/assets/js/custom/navigation.js
+++ b/assets/js/custom/navigation.js
@@ -1,0 +1,113 @@
+
+function adjustSidebar() {
+  // Identify the URL of the loaded page
+  var loadedPageUrl = window.location.pathname;
+
+  // Get the "sidebar" element
+  var sidebarElement = document.querySelector('.sidebar');
+  // If "sidebar" element exists, find the corresponding navigator item within it
+  if (sidebarElement) {
+    // Get all <a> elements in the navigation list within the "sidebar"
+    var navLinks = sidebarElement.querySelectorAll('.nav__list .nav-link');
+
+    // Enumerate through each <a> element and remove the "active" class
+    navLinks.forEach(navLink => {
+      navLink.classList.remove('active');
+    });
+
+    // Find the corresponding navigator item with matching URL within the "sidebar"
+    var matchingNavItem = sidebarElement.querySelector('.nav__list .nav-link[href="' + loadedPageUrl + '"]');
+
+    // If a matching item is found, mark it as "active"
+    if (matchingNavItem) {
+      matchingNavItem.classList.add('active');
+
+      // Expand all parent ul elements up to the nearest .nav__list
+      var parentUl = matchingNavItem.closest('ul');
+      while (parentUl) {
+        var parentCheckbox = parentUl.previousElementSibling.previousElementSibling;
+        if (parentCheckbox && parentCheckbox.tagName === 'INPUT' && parentCheckbox.type === 'checkbox')
+          parentCheckbox.checked = true;
+
+        var immediateParent = parentUl.parentElement;
+        if (immediateParent.classList.contains('nav__list'))
+          break;
+
+        parentUl = immediateParent.closest('ul');
+      }
+
+      // Ensure the active item is visible within the "sidebar"
+      // TODO: This one is also not too reliable, browser dependant,get a better solution
+      matchingNavItem.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }
+}
+
+// Function to load content based on relative URL
+function loadContentFromUrl(url) {
+  var currContentContainer = document.querySelector('article');
+
+  fetch(url)
+    .then(response => {
+      if (!response.ok) {
+        throw new Error('Page not found');
+      }
+      return response.text();
+    })
+    .then(html => {
+      // Parse the HTML string to create a DOM document
+      var parser = new DOMParser();
+      var doc = parser.parseFromString(html, 'text/html');
+      // Find the "article" element in the parsed document
+      var newContent = doc.querySelector('article');
+
+      // FIXME: This does not work, double check
+      currContentContainer.scrollTop;
+
+      // As a workaround of the above, empty the old content, and with a short delay only, load the new one
+      currContentContainer.innerHTML = '';
+
+      // Replace the old content, but only with a small delay, to make sure the content reset takes effect
+      setTimeout(function () {
+        // Replace the old content with the loaded content
+        currContentContainer.parentNode.replaceChild(newContent, currContentContainer);
+        // Sync the sidebar with the current page url, migth be out of sync when the page is loaded initially from an inner url
+        adjustSidebar();
+        // There might be nav-links in the loaded new content as well (e.g.Next / Prev buttons
+        // so, handle the links here as the last action
+        updateNavLinks();
+      }, 100);
+    })
+    .catch(error => {
+      contentContainer.innerHTML = '<h2>Error loading content</h2>';
+    });
+}
+
+// Function to handle link clicks
+function handleLinkClick(event) {
+  event.preventDefault(); // Prevent default navigation behavior
+
+  // Get the relative URL value and update the browser URL
+  var url = new URL(event.target.href).pathname;
+  history.pushState(null, null, url);
+
+  // Load content based on the updated relative URL
+  loadContentFromUrl(url);
+}
+
+function updateNavLinks(event) {
+  // Attach click event listeners to all links with class 'nav-link'
+  var navLinks = document.querySelectorAll('.nav-link');
+  navLinks.forEach(function (link) {
+    link.addEventListener('click', handleLinkClick);
+  });
+}
+
+// Initial load based on the relative URL if needed 
+// (e.g. when an inner embedded page link is opened directly in a new tab)
+loadContentFromUrl(window.location.pathname);
+
+// Listen for popstate events and update content accordingly
+window.addEventListener('popstate', function () {
+  loadContentFromUrl(window.location.pathname);
+});


### PR DESCRIPTION
just loads them into the right content panel

Sidebar navigator now should sync its active item, open it up and select automatically according to the active content in the right content panel and URL

Signed-off-by: Hofi <hofione@gmail.com>