### PR TITLE
Links genereation is running only now if JEKYLL_BUILD_LINKS='true'  env var is presented

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -68,11 +68,13 @@ jobs:
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: |
-          # FIXME: a duble build is needed currently as the _data/links/ content must be rendered from the final html output, so
+          # A double build is needed currently as the _data/links/ content must be rendered from the final html output, so
           # the first run cannot use the not yet existing links
           #
+          JEKYLL_BUILD_LINKS='true' bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+
           bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
-          bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+
           ls -AlR ./_site/assets/js          
         env:
           JEKYLL_ENV: production

--- a/_plugins/generate_helper.rb
+++ b/_plugins/generate_helper.rb
@@ -97,6 +97,7 @@ module Jekyll
     public
 
     def generate(site)
+      shoud_build_links = (ENV['JEKYLL_BUILD_LINKS'] == 'true')
       markdown_extensions = site.config['markdown_ext'].split(',').map { |ext| ".#{ext.strip}" }
 
       site.layouts.each_value do |layout|
@@ -105,12 +106,12 @@ module Jekyll
       #puts ""
 
       site.pages.each do |page|
-        do_work(site, markdown_extensions, page, true)
+        do_work(site, markdown_extensions, page, shoud_build_links)
       end
       #puts ""
 
       site.documents.each do |document|
-        do_work(site, markdown_extensions, document, true)
+        do_work(site, markdown_extensions, document, shoud_build_links)
       end
       #puts ""
     end

--- a/_tools/navgen
+++ b/_tools/navgen
@@ -179,13 +179,20 @@ gen_navigation()
 
         shift
     done
+    echo "YAML navigation structure is generated and saved to $OUTPUT_FILE"
+}
+
+gen_links()
+{
+    rm -Rf _data/links
+    JEKYLL_BUILD_LINKS='true' bundle exec jekyll build
+    echo "Jekyll page links are generated and saved to _data/links"
 }
 
 process_params()
 {
     gen_navigation
-    
-    echo "YAML structure and page links have  been generated and saved to $OUTPUT_FILE"
+    gen_links
 }
 
 

--- a/_tools/serve
+++ b/_tools/serve
@@ -34,11 +34,8 @@ start_process() {
     reset_watcher
 
     rm -Rf _site
-    rm -Rf _data/links
     rm -Rf .jekyll-cache
 
-    # TODO: We need a pre (double) build as the _data/links folder currently generated from th
-    bundle exec jekyll build
     bundle exec jekyll serve ${ALL_PARAMS} &
     PROC_PID=$!
 


### PR DESCRIPTION
Also, added as an automatic step to navgen

Signed-off-by: Hofi <hofione@gmail.com>