### PR TITLE
Links generation now can be turned off in navgen

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -51,7 +51,11 @@ jobs:
           pwd
           
           mkdir -p _data
-          ./_tools/navgen "./doc" "./_data/navigation.yml"
+          # Last param turns off jekyll build for the links, let it be done in the next step, 
+          # together with the real site build, with the same parameters
+          #
+          ./_tools/navgen "./doc" "./_data/navigation.yml" "no"
+          
           ls -Al _data/navigation.yml
 
           # This one is just for sure to have our final scripts result inplace 

--- a/_tools/navgen
+++ b/_tools/navgen
@@ -6,6 +6,7 @@ FRONT_MATTER_HEADER_FOOTER="---"
 
 USE_INDEX_FILE_FOR_FOLDER_LINKS="yes"
 REMOVE_UNDERLINE_FROM_DOC_DIR_NAMES="yes"
+GENERATE_LINKS="yes"
 
 
 trim_trailing_slashes()
@@ -192,17 +193,20 @@ gen_links()
 process_params()
 {
     gen_navigation
-    gen_links
+    [ "${GENERATE_LINKS}" == "yes" ] && gen_links
 }
 
 
 # Check for the correct number of command-line parameters
 if [ "$#" -lt 2 ]; then
-    echo "Usage: $0 <doc_folder> <output_nav_file>"
+    echo "Usage: $0 <doc_folder> <output_nav_file> [yes:no]"
     exit 1
 fi
 
 DOC_FOLDER="${1}"
-OUTPUT_FILE="${2}"    
+OUTPUT_FILE="${2}"
+[ "$#" -gt 2 ] && GENERATE_LINKS="${3}"
 
 process_params "$@"
+
+exit 0

--- a/doc/_doc-guide/README.md
+++ b/doc/_doc-guide/README.md
@@ -97,18 +97,18 @@ We have a few useful tools in the `${PROJECT_ROOT}/_tools` folder some of them w
 
       Note: Unlike `--liverolad`, this will restart `jekyll serve` and not refreshing the opened web pages, so you have to refresh the opend pages
       {: .notice}
-2. Generating the left sidebar navigator content is semi-automatic yet, its content is generated from the `${PROJECT_ROOT}/_data/navigation.yml` file that will be read by jekyll automatically during the site build process, but adding the correct content of it is our responsibility. Fortunately we have already a helper to simplify this, you can call it from the `${PROJECT_ROOT}` like
+2. Generating the left sidebar navigator content, the page, and anchor links is semi-automatic yet, their content is generated from the `${PROJECT_ROOT}/_data/navigation.yml` file that will be read by jekyll automatically during the site build process, but adding the correct content of it is our responsibility. Fortunately we have already a helper to simplify this, you can call it from the `${PROJECT_ROOT}` like
 
     ```shell
     ./_tools/navgen ./doc ./_data/navigation.yml
     ```
 
-    This will update the `navigation.yml` file based on the content of the `${PROJECT_ROOT}/_doc` folder where all of our doumentation markdown files are located.
+    This will update the `navigation.yml` file based on the content of the `${PROJECT_ROOT}/_doc` folder where all of our doumentation markdown files are located, and also update the page, and anchor links in the `${PROJECT_ROOT}/_data/links/` folder (generation of the links can be turned off providing a 3rd param which not equals to `'yes'`, like `'no'`)
 
     Note: Automation of this during development is in progress, the `serve` tool will take care of this as well in the future.
     {: .notice}
 
-    Important: This tools is part of the GitHub deployment workflow too, so any modification you add to `${PROJECT_ROOT}/_data/navigation.yml` will be lost during the site build.
+    Important: This tools is part of the GitHub deployment workflow too, so any modification you add to `${PROJECT_ROOT}/_data/navigation.yml` file or `${PROJECT_ROOT}/_data/links` folder will be lost during the site build.
     {: .notice--danger}
 3. Sometimes its neded to [update][ref:mm-javascripts] the internally used `minimal-mistakes` theme default [.js scripts][ref:mm-js-update] \
     If you modify any of the scripts packed into the `${PROJECT_ROOT}/assets/js/main.min.js` file, you have to [re-pack][ref:mm-js-update] it.


### PR DESCRIPTION
CI build uses a dedicated jekyll build step to generate the links
Signed-off-by: Hofi <hofione@gmail.com>