### PR TITLE
Links are now excluded from jekyll parsing

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -62,6 +62,9 @@ exclude:
   #- assets/js
   - _js/ 
   - _tools/
+  # This one does not work either, as it seems .yml files are always parsed, so the content file extensions are renamed to .lnk
+  # that will not be parsed :S
+  - _data/links/*.yml
   - Gemfile
   - Gemfile.lock
   - node_modules

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -13,10 +13,6 @@ admin-guide-nav:
   - title: "Preface"
     url: /admin-guide/000_Preface/README
     subnav:
-    - title: "Target audience and prerequisites"
-      url: /admin-guide/000_Preface/000_Target_audience
-    - title: "Acknowledgments"
-      url: /admin-guide/000_Preface/001_Acknowledgements
   - title: "Introduction to syslog-ng"
     url: /admin-guide/010_Introduction_to_syslog-ng/README
     subnav:
@@ -391,7 +387,7 @@ admin-guide-nav:
     - title: "opensearch"
       url: /admin-guide/070_Destinations/155_opensearch/README
       subnav:
-      - title: "Batch mode and load balancing "
+      - title: "Batch mode and load balancing"
         url: /admin-guide/070_Destinations/155_opensearch/000_batch-mode
       - title: "OpenSearch() destination options "
         url: /admin-guide/070_Destinations/155_opensearch/001_opensearch()-destination-options
@@ -435,6 +431,8 @@ admin-guide-nav:
     - title: "s3"
       url: /admin-guide/070_Destinations/225_Amazon-s3/README
       subnav:
+      - title: "Amazon s3 options"
+        url: /admin-guide/070_Destinations/225_Amazon-s3/000_amazon_s3_options
     - title: "slack"
       url: /admin-guide/070_Destinations/230_Slack/README
       subnav:
@@ -452,8 +450,11 @@ admin-guide-nav:
         url: /admin-guide/070_Destinations/250_snmp/000_Converting_Cisco_messages
       - title: "snmp() destination options"
         url: /admin-guide/070_Destinations/250_snmp/001_snmp_options
-    - title: "SPLUNK"
-      url: /admin-guide/070_Destinations/260_Splunk
+    - title: "Splunk"
+      url: /admin-guide/070_Destinations/260_Splunk/README
+      subnav:
+      - title: "splunk-hec-event: Send log messages to Splunk HEC' "
+        url: /admin-guide/070_Destinations/260_Splunk/000_Splunk-hec-event
     - title: "sql"
       url: /admin-guide/070_Destinations/270_sql/README
       subnav:
@@ -470,6 +471,11 @@ admin-guide-nav:
           url: /admin-guide/070_Destinations/270_sql/002_Interaction/001_mssql_specific_interaction_methods
       - title: "sql() destination options"
         url: /admin-guide/070_Destinations/270_sql/003_sql_destination_options
+    - title: "stdout: Send messages to standard output"
+      url: /admin-guide/070_Destinations/275_stdout/README
+      subnav:
+      - title: "stdout options"
+        url: /admin-guide/070_Destinations/275_stdout/000_stdout_options
     - title: "Stomp"
       url: /admin-guide/070_Destinations/280_Stomp/README
       subnav:

--- a/_plugins/generate_links.rb
+++ b/_plugins/generate_links.rb
@@ -65,11 +65,11 @@ module Jekyll
                   "id" => page_id + "##{heading_id}",
                   "url" => page_url + "##{heading_id}",
                   "title" => '"' + heading.text + '"',
-                  "description" => '""'              
+                  "description" => '""'
                 }
 
                 # Write data to separate YAML file for each heading
-                file_path = "_data/links/#{page_id}##{heading_id}.yml"
+                file_path = "_data/links/#{page_id}##{heading_id}.lnk"
                 write_yaml_file(file_path, link_data)
               end
             end
@@ -80,10 +80,10 @@ module Jekyll
               "id" => page_id,
               "url" => page_url,
               "title" => '"' + page_title + '"',
-              "description" => '"' + page_description + '"'              
+              "description" => '"' + page_description + '"'
             }
             # Write data to separate YAML file for each page
-            page_file_path = "#{page_id}.yml"
+            page_file_path = "#{page_id}.lnk"
             page_file_path = "_data/links/" + page_file_path.gsub(/\/|:|\s/, "-").downcase
             write_yaml_file(page_file_path, page_link_data)
           

--- a/_plugins/generate_tooltips.rb
+++ b/_plugins/generate_tooltips.rb
@@ -36,7 +36,7 @@ module Jekyll
           id = match_parts[1]
         end
 
-        tooltip = '{% include markdown_link id="' + id + '" title="%MATCH%"' + (url_has_anchor || description ? ' withTooltip="yes"' : '') + ' %}' #'abrakadabra'
+        tooltip = '{% include markdown_link id=\'' + id + '\' title=\'%MATCH%\'' + (url_has_anchor || description ? ' withTooltip=\'yes\'' : '') + ' %}' #'abrakadabra'
         replacement_text = tooltip.gsub(/#{Regexp.escape('%MATCH%')}/, match)
         puts "replacement_text: " + replacement_text
         
@@ -233,7 +233,7 @@ Jekyll::Hooks.register :site, :pre_render do |site, payload|
   if shoud_build_tooltips    
     markdown_extensions = site.config['markdown_ext'].split(',').map { |ext| ".#{ext.strip}" }
     # Skip shorter than 3 letter long (e.g. Glossary header) anchor items (for testing: https://rubular.com/)
-    page_links = Jekyll::TooltipGen.gen_page_link_data('_data/links', /\/adm-(([^#]+)|(.*\#{1}.{3,}))\.yml\z/)
+    page_links = Jekyll::TooltipGen.gen_page_link_data('_data/links', /\/adm-(([^#]+)|(.*\#{1}.{3,}))\.lnk\z/)
     #page_links = Jekyll::TooltipGen.gen_page_link_data('_data/links', /\/(adm|dev|doc)-(([^#]+)|(.*\#{1}.{3,}))\.yml\z/)
     #page_links = Jekyll::TooltipGen.gen_page_link_data('_data/links', 'adm-temp-macro-ose#message.yml')
     #puts page_links


### PR DESCRIPTION
links are using .lnk extensions from now and on
Signed-off-by: Hofi <hofione@gmail.com>