### PR TITLE
pi-hole FTL and -arr() sources for 4.7

### DIFF
--- a/doc/_admin-guide/060_Sources/025_Arr_logs/README.md
+++ b/doc/_admin-guide/060_Sources/025_Arr_logs/README.md
@@ -1,0 +1,32 @@
+---
+title: Arr log source
+short_title: Arr logs
+id: adm-src-arr
+description: >-
+    In syslog-ng OSE 4.7 and later versions it is possible to collect logs of the [Lidarr, Prowlarr, Radarr, Readarr, and Sonarr](https://github.com/Servarr/Wiki) (referred to as “*Arr” or “*Arrs”) applications.
+---
+
+The new arr() sources are the following:
+
+* lidarr()
+* prowlarr()
+* radarr()
+* readarr()
+* sonarr()
+* whisparr()
+
+### Example: minimal config of arr sources
+
+```config
+source s_radarr {
+    radarr(
+    dir("/path/to/my/radarr/log/dir")
+    );
+};
+```
+
+The logging module is stored in the &lt;prefix&gt;&lt;module&gt; name-value pair, for example: `.radarr.module` => `ImportListSyncService`.
+
+The prefix can be modified with the `prefix()` option.
+
+This driver is a reusable configuration snippet. For details on using or writing such configuration snippets, see Reusing configuration blocks. The source of this configuration snippet can be accessed on [GitHub](https://github.com/syslog-ng/syslog-ng/blob/master/scl/arr/arr.conf).

--- a/doc/_admin-guide/060_Sources/105_pi-hole-FTL/README.md
+++ b/doc/_admin-guide/060_Sources/105_pi-hole-FTL/README.md
@@ -1,0 +1,17 @@
+---
+title: Pi-hole Faster Than Light log source
+short_title: Pi-hole FTL
+id: adm-src-piftl
+description: >-
+    In syslog-ng OSE 4.6 and later versions it is possible to collect logs of the [Pi-hole](https://pi-hole.net/) FTL (Faster Than Light) application.
+---
+
+```config
+source s_pihole_ftl {
+  pihole-ftl();
+};
+```
+
+By default, the source reads the `/var/log/pihole/FTL.log` file. If the root directory of the Pi-hole installation is different, specify the directory where the `FTL.log` file is with the dir() option. The root log directory can be accessed by selecting **Tools** > **Pi-hole diagnosis** in the Pi-hole application. The `pihole-ftl()` source has the same parameters as the file() source.
+
+The `pihole-ftl()` driver is a reusable configuration snippet. For details on using or writing configuration snippets, see Reusing configuration blocks. The source of this configuration snippet can be accessed on [GitHub](https://github.com/syslog-ng/syslog-ng/tree/master/scl/pihole).


### PR DESCRIPTION
pi-hole FTl and Lidarr, radarr (-arr logs)... sources documented for 4.7